### PR TITLE
Support setting JAVA_HOME, multiple agents per user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? "= #{ENV['PUPPET_GEM_VERSION']}" : '>= 3.3'
+puppetversion = ENV.key?('PUPPET_GEM_VERSION') ? "= #{ENV['PUPPET_GEM_VERSION']}" : '>= 4.0'
 
 if RUBY_VERSION.start_with? '1.9'
   gem 'json_pure', '< 2.0'

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ class { 'bamboo_agent':
       }
     },
     'bamboo-agent2' => {
+      java_home  => '/etc/alternatives/jre_1.8.0',
       home       => '/var/lib/bamboo-agent2',
       server_url => 'https://bamboo.example.com',
     }
@@ -82,7 +83,7 @@ bamboo_agent::agents:
 
 ## Reference
 
-### Class `bamboo_agent` 
+### Class `bamboo_agent`
 The main class.
 #### Parameters
 * `agents`: Accepts a hash. See the bamboo_agent::agent defined type for accepted parameters
@@ -105,9 +106,11 @@ The main class.
     - Default: `$title`
 * `user_groups`: *optional* Groups bamboo-agent user should be a member of
 * `manage_capabilities`: *optional* Whether the module should manage the bamboo-agent's capabilities file
-    - Default: `true` 
+    - Default: `true`
 * `wrapper_conf_properties`: *optoinal* Options to be placed in the bamboo-agent's wrapper.conf file
     - Default: `{}`
+* `java_home`: *optoinal* Specify a value for the `JAVA_HOME` environment variable to include in the system init script.
+    - Default: unset
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ The main class.
     - Default: `true`
 * `wrapper_conf_properties`: *optoinal* Options to be placed in the bamboo-agent's wrapper.conf file
     - Default: `{}`
-* `java_home`: *optoinal* Specify a value for the `JAVA_HOME` environment variable to include in the system init script.
+* `service_name`: *optional* Specify a unique name for the configured system service to be known as.
+    - Default: `$title`
+* `java_home`: *optional* Specify a value for the `JAVA_HOME` environment variable to include in the system init script.
     - Default: unset
 
 ## Limitations

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -12,18 +12,18 @@
 # @param manage_capabilities Whether the module should manage the capabilities file for the agent
 # @param wrapper_conf_properties Additonal java arguments to put in wrapper.conf
 define bamboo_agent::agent (
-  String  $home,
-  String  $server_url,
-  Hash    $capabilities = {},
-  Boolean $manage_user = true,
-  Boolean $manage_groups = false,
-  Boolean $manage_home = true,
-  String  $username = $title,
-  String  $service_name = $title,
-  Array   $user_groups = [],
-  Boolean $manage_capabilities = true,
-  Hash    $wrapper_conf_properties = {},
-  Optional[String] $java_home = undef,
+  String           $home,
+  String           $server_url,
+  Hash             $capabilities            = {},
+  Boolean          $manage_user             = true,
+  Boolean          $manage_groups           = false,
+  Boolean          $manage_home             = true,
+  String           $username                = $title,
+  String           $service_name            = $title,
+  Array            $user_groups             = [],
+  Boolean          $manage_capabilities     = true,
+  Hash             $wrapper_conf_properties = {},
+  Optional[String] $java_home               = undef,
 ) {
 
   if $manage_groups == true {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -11,19 +11,20 @@
 # @param user_groups A list of groups to add the bamboo-agent user too
 # @param manage_capabilities Whether the module should manage the capabilities file for the agent
 # @param wrapper_conf_properties Additonal java arguments to put in wrapper.conf
-define bamboo_agent::agent(
-  $home,
-  $server_url,
-  $capabilities = {},
-  $manage_user = true,
-  $manage_groups = false,
-  $manage_home = true,
-  $username = $title,
-  $user_groups = [],
-  $manage_capabilities = true,
-  $wrapper_conf_properties = {},
-  )
-{
+define bamboo_agent::agent (
+  String  $home,
+  String  $server_url,
+  Hash    $capabilities = {},
+  Boolean $manage_user = true,
+  Boolean $manage_groups = false,
+  Boolean $manage_home = true,
+  String  $username = $title,
+  String  $service_name = $title,
+  Array   $user_groups = [],
+  Boolean $manage_capabilities = true,
+  Hash    $wrapper_conf_properties = {},
+  Optional[String] $java_home = undef,
+) {
 
   if $manage_groups == true {
     group {$user_groups:
@@ -49,32 +50,34 @@ define bamboo_agent::agent(
     }
   }
 
-  bamboo_agent::install {$username:
+  bamboo_agent::install {$service_name:
     home       => $home,
     username   => $username,
     server_url => $server_url,
+    java_home  => $java_home,
   }
-  ~>
+
   if $manage_capabilities == true {
-    bamboo_agent::capabilities{$username:
+    bamboo_agent::capabilities{$service_name:
       home         => $home,
       username     => $username,
       capabilities => $capabilities,
-      require      => User[$username],
-      notify       => Service[$username]
+      require      => [ User[$username], Bamboo_agent::Install[$service_name], ],
+      notify       => Service[$service_name],
     }
   }
 
-  bamboo_agent::wrapper_conf {$username:
+  bamboo_agent::wrapper_conf {$service_name:
     home       => $home,
     properties => $wrapper_conf_properties,
-    notify     => Service[$username]
+    notify     => Service[$service_name]
   }
 
-  bamboo_agent::service{$username:
-    username => $username,
-    home     => $home,
-    require  => Bamboo_Agent::Install[$username]
+  bamboo_agent::service{$service_name:
+    username  => $username,
+    home      => $home,
+    java_home => $java_home,
+    require   => Bamboo_Agent::Install[$service_name],
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,27 +5,35 @@
 # @param username username of the bamboo-agent account
 # @param server_url the url for the bamboo server
 define bamboo_agent::install (
-  $home,
-  $username,
-  $server_url,
+  String $home,
+  String $username,
+  String $server_url,
+  Optional[String] $java_home = undef,
   )
 {
   assert_private()
 
+  $path = $java_home ? {
+    Undef   => [ "${java_home}/bin", '/bin', '/usr/bin', '/usr/local/bin' ],
+    default => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+  }
+
   exec {"download-${title}-bamboo-agent-jar":
-    command => "wget ${server_url}/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar",
+    command => "wget --no-check-certificate ${server_url}/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar",
     cwd     => $home,
     user    => $username,
     path    => ['/usr/bin', '/bin'],
     creates => "${home}/atlassian-bamboo-agent-installer.jar",
     require => File[$home],
   }
-  ->
+
   exec { "install-${title}-bamboo-agent":
     command => "java -jar -Dbamboo.home=${home} atlassian-bamboo-agent-installer.jar ${server_url}/agentServer/ install",
     cwd     => $home,
     user    => $username,
-    path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    path    => [ "${java_home}/bin", '/bin', '/usr/bin', '/usr/local/bin' ],
     creates => "${home}/bin/bamboo-agent.sh",
+    require => Exec["download-${title}-bamboo-agent-jar"],
   }
 }
+

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,8 +14,8 @@ define bamboo_agent::install (
   assert_private()
 
   $path = $java_home ? {
-    Undef   => [ "${java_home}/bin", '/bin', '/usr/bin', '/usr/local/bin' ],
-    default => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    Undef   => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+    default => [ "${java_home}/bin", '/bin', '/usr/bin', '/usr/local/bin' ],
   }
 
   exec {"download-${title}-bamboo-agent-jar":
@@ -31,7 +31,7 @@ define bamboo_agent::install (
     command => "java -jar -Dbamboo.home=${home} atlassian-bamboo-agent-installer.jar ${server_url}/agentServer/ install",
     cwd     => $home,
     user    => $username,
-    path    => [ "${java_home}/bin", '/bin', '/usr/bin', '/usr/local/bin' ],
+    path    => $path,
     creates => "${home}/bin/bamboo-agent.sh",
     require => Exec["download-${title}-bamboo-agent-jar"],
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,8 +2,10 @@
 # @param username username of the bamboo-agent service account
 # @param home home directory of the bamboo-agent user
 define bamboo_agent::service(
-  $username,
-  $home,
+  String $username,
+  String $home,
+  String $service_name = $title,
+  Optional[String] $java_home,
   ){
 
   assert_private()
@@ -14,12 +16,12 @@ define bamboo_agent::service(
         'xenial': {
           $init_path     = '/lib/systemd/system'
           $service_template = 'bamboo_agent/unit.erb'
-          $initscript = "${init_path}/${username}.service"
+          $initscript = "${init_path}/${service_name}.service"
         }
         default: {
           $init_path = '/etc/init.d'
           $service_template = 'bamboo_agent/init.sh.erb'
-          $initscript = "${init_path}/${username}"
+          $initscript = "${init_path}/${service_name}"
         }
       }
     }
@@ -28,19 +30,19 @@ define bamboo_agent::service(
         '7': {
           $init_path     = '/lib/systemd/system'
           $service_template = 'bamboo_agent/unit.erb'
-          $initscript = "${init_path}/${username}.service"
+          $initscript = "${init_path}/${service_name}.service"
         }
         default: {
           $init_path = '/etc/init.d'
           $service_template = 'bamboo_agent/init.sh.erb'
-          $initscript = "${init_path}/${username}"
+          $initscript = "${init_path}/${service_name}"
         }
       }
     }
     default: {
       $init_path = '/etc/init.d'
       $service_template = 'bamboo_agent/init.sh.erb'
-      $initscript = "${init_path}/${username}"
+      $initscript = "${init_path}/${service_name}"
     }
   }
 
@@ -54,7 +56,7 @@ define bamboo_agent::service(
     content => template($service_template)
   }
 
-  service { $username:
+  service { $service_name:
     ensure  => running,
     enable  => true,
     require => File[$initscript]

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,7 @@ define bamboo_agent::service (
   String           $username,
   String           $home,
   String           $service_name = $title,
-  Optional[String] $java_home,
+  Optional[String] $java_home = undef,
 ) {
 
   assert_private()

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,12 +1,12 @@
 # set up the service
 # @param username username of the bamboo-agent service account
 # @param home home directory of the bamboo-agent user
-define bamboo_agent::service(
-  String $username,
-  String $home,
-  String $service_name = $title,
+define bamboo_agent::service (
+  String           $username,
+  String           $home,
+  String           $service_name = $title,
   Optional[String] $java_home,
-  ){
+) {
 
   assert_private()
 
@@ -14,51 +14,49 @@ define bamboo_agent::service(
     'Ubuntu': {
       case $::lsbdistcodename {
         'xenial': {
-          $init_path     = '/lib/systemd/system'
+          $init_path        = '/lib/systemd/system'
           $service_template = 'bamboo_agent/unit.erb'
-          $initscript = "${init_path}/${service_name}.service"
+          $initscript       = "${init_path}/${service_name}.service"
         }
         default: {
-          $init_path = '/etc/init.d'
+          $init_path        = '/etc/init.d'
           $service_template = 'bamboo_agent/init.sh.erb'
-          $initscript = "${init_path}/${service_name}"
+          $initscript       = "${init_path}/${service_name}"
         }
       }
     }
     'Redhat','CentOS': {
       case $::operatingsystemmajrelease {
         '7': {
-          $init_path     = '/lib/systemd/system'
+          $init_path        = '/lib/systemd/system'
           $service_template = 'bamboo_agent/unit.erb'
-          $initscript = "${init_path}/${service_name}.service"
+          $initscript       = "${init_path}/${service_name}.service"
         }
         default: {
-          $init_path = '/etc/init.d'
+          $init_path        = '/etc/init.d'
           $service_template = 'bamboo_agent/init.sh.erb'
-          $initscript = "${init_path}/${service_name}"
+          $initscript       = "${init_path}/${service_name}"
         }
       }
     }
     default: {
-      $init_path = '/etc/init.d'
+      $init_path        = '/etc/init.d'
       $service_template = 'bamboo_agent/init.sh.erb'
-      $initscript = "${init_path}/${service_name}"
+      $initscript       = "${init_path}/${service_name}"
     }
   }
-
-
 
   file {$initscript:
     ensure  => present,
     owner   => 'root',
     group   => 'root',
     mode    => '0755',
-    content => template($service_template)
+    content => template($service_template),
   }
 
   service { $service_name:
     ensure  => running,
     enable  => true,
-    require => File[$initscript]
+    require => File[$initscript],
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -71,7 +71,7 @@ describe 'bamboo_agent' do
         it { should contain_bamboo_agent__install('test-agent2')}
         it do
           should contain_exec('download-test-agent-bamboo-agent-jar').with(
-            'command' => 'wget https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
+            'command' => 'wget --no-check-certificate https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
             'cwd'     => '/home/test-agent',
             'user'    => 'test-agent',
             'path'    => ['/usr/bin','/bin'],
@@ -79,7 +79,7 @@ describe 'bamboo_agent' do
         end
         it do
           should contain_exec('download-test-agent2-bamboo-agent-jar').with(
-            'command' => 'wget https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
+            'command' => 'wget --no-check-certificate https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
             'cwd'     => '/home/test-agent2',
             'user'    => 'test-agent2',
             'path'    => ['/usr/bin','/bin'],

--- a/spec/defines/agent_spec.rb
+++ b/spec/defines/agent_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe 'bamboo_agent::agent' do
 
   on_supported_os.each do |os, facts|
+    puts "os: #{os}"
     context "on #{os}" do
       let(:facts) do
         facts.merge({

--- a/spec/defines/agent_spec.rb
+++ b/spec/defines/agent_spec.rb
@@ -43,7 +43,7 @@ describe 'bamboo_agent::agent' do
         it { should contain_bamboo_agent__install('test-agent')}
         it do
           should contain_exec('download-test-agent-bamboo-agent-jar').with(
-            'command' => 'wget https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
+            'command' => 'wget --no-check-certificate https://bamboo.example.com/agentServer/agentInstaller/atlassian-bamboo-agent-installer.jar',
             'cwd'     => '/home/test-agent',
             'user'    => 'test-agent',
             'path'    => ['/usr/bin','/bin'],

--- a/templates/init.sh.erb
+++ b/templates/init.sh.erb
@@ -17,28 +17,28 @@
 #
 # It was then hacked on a bit to actually work. :-(
 
-# Define some variables
 # Name of app ( bamboo, Confluence, etc )
 APP=<%= @username %>
+
 # Name of the user to run as
 USER=<%= @username %>
+
 # Location of application's bin directory
 BASE=<%= @home %>
 
+export JAVA_HOME=<%= @java_home %>
+
 case "$1" in
-  # Start command
   start)
     chown -R <%= @username %>:<%= @username %> $BASE
     echo "Starting $APP"
-    /bin/su - $USER -c "export BAMBOO_HOME=${BAMBOO_HOME}; $BASE/bin/bamboo-agent.sh start &> /dev/null"
+    /bin/su - $USER -c "$BASE/bin/bamboo-agent.sh start &> /dev/null"
     ;;
-  # Stop command
   stop)
     echo "Stopping $APP"
     /bin/su - $USER -c "$BASE/bin/bamboo-agent.sh stop &> /dev/null"
     echo "$APP stopped successfully"
     ;;
-  # Restart command
   restart)
     $0 stop
     sleep 5

--- a/templates/unit.erb
+++ b/templates/unit.erb
@@ -8,6 +8,10 @@ User=<%= @username %>
 Group=<%= @username %>
 ExecStart=<%= @home %>/bin/bamboo-agent.sh start
 ExecStop=<%= @home %>/bin/bamboo-agent.sh stop
+<% if @java_home -%>
+Environment=JAVA_HOME=<%= @java_home %>
+<% end %>
 
 [Install]
 WantedBy=multi-user.target
+


### PR DESCRIPTION
Warning: This has some refactoring to make use of Puppet 4 data validation and such things. It also will now name services based off the key in the agent hash (and allows overriding by specifying a `server_name` parameter). 

I found I needed the ability to set JAVA_HOME to a specific Java version, which was the initial impetus to make these updates. Then I found that we need to run multiple agents on one machine under the same user. 

I won't be at all offended/surprised if you reject this PR, but I'd be keen to know your thoughts and feedback. 