### PR TITLE
SDJ-7037: Update ulimit settings prior to launching bamboo agent

### DIFF
--- a/templates/init.sh.erb
+++ b/templates/init.sh.erb
@@ -31,6 +31,8 @@ export JAVA_HOME=<%= @java_home %>
 case "$1" in
   start)
     chown -R <%= @username %>:<%= @username %> $BASE
+    echo "Setting max locked memory"
+    ulimit -l unlimited
     echo "Starting $APP"
     /bin/su - $USER -c "$BASE/bin/bamboo-agent.sh start &> /dev/null"
     ;;


### PR DESCRIPTION
The limits.conf does not get used by init.d startup scripts.  So even though they are setting up the memlock correctly, it is not being used by the startup scripts on boot.

Add running ulimit inside the startup scripts.  If we move to using systemd startup scripts, there are more elegant ways to manage this.