### PR TITLE
Resolve Duplicate resources

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -29,11 +29,16 @@ define bamboo_agent::agent (
   Optional[String] $java_home               = undef,
 ) {
 
+  # Ensure all groups are created
   if $manage_groups == true {
-    group {$user_groups:
-      ensure => present,
+    $user_groups.each |$group_name| {
+      group { "bamboo_agent_${group_name}":
+        ensure => present,
+        name   => $group_name,
+      }
     }
   }
+
   # setup user
   if $manage_user == true {
     user { $username:

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,7 +39,7 @@ describe 'bamboo_agent' do
       end
       context 'it should create the user' do
         it do
-          should contain_group('foo')
+          should contain_group('bamboo_agent_foo')
         end
         it do should contain_user('test-agent').with(
           'ensure'  => 'present',


### PR DESCRIPTION
Updated bamboo agent hiera data to manage the groups.  But there is another rule for the rvm group.  Need to rename the targets so that they don't conflict.